### PR TITLE
Added property to check if a trophy not achieved on "target" PS3 is already synchronized or not.

### DIFF
--- a/TROPHYParser/TROPUSR.cs
+++ b/TROPHYParser/TROPUSR.cs
@@ -194,7 +194,7 @@ namespace TROPHYParser
 
         public void LockTrophy(int id) {
             TrophyTimeInfo tti = trophyTimeInfoTable[id];
-            if ((tti.SyncState == 0x100100) || (tti.SyncState == 0x100))
+            if (tti.IsSync)
                 throw new Exception("此獎杯已同步過，無法上鎖或修改");
 
             tti.Time = new DateTime(0);

--- a/TROPHYParser/TROPUSR.cs
+++ b/TROPHYParser/TROPUSR.cs
@@ -194,7 +194,7 @@ namespace TROPHYParser
 
         public void LockTrophy(int id) {
             TrophyTimeInfo tti = trophyTimeInfoTable[id];
-            if (tti.SyncState == 0x100100)
+            if ((tti.SyncState == 0x100100) || (tti.SyncState == 0x100))
                 throw new Exception("此獎杯已同步過，無法上鎖或修改");
 
             tti.Time = new DateTime(0);

--- a/TROPHYParser/TROPUSR.cs
+++ b/TROPHYParser/TROPUSR.cs
@@ -474,6 +474,8 @@ namespace TROPHYParser
             /// int
             public int SyncState;
 
+            public bool IsSync => (SyncState == 0x100100) || (SyncState == 0x100);
+
             /// int
             public int unknow2;
 


### PR DESCRIPTION
Added a new property, because TrophyIsGood was considering already sync trophies as "not synchronized":

0x0: means not achieved;
0x100: means achieved on another PS3 (synchronized, came from PSN, not achieved on "this" PS3);
0x100000: means achieved on "this" PS3;
0x100100: means achieved and synchronized on "this" PS3.

