### PR TITLE
Add support for RPCS3

### DIFF
--- a/TROPHYParser/TROPCONF.cs
+++ b/TROPHYParser/TROPCONF.cs
@@ -10,7 +10,6 @@ namespace TROPHYParser
     {
         private const string TROPCONF_FILE_NAME = "TROPCONF.SFM";
 
-        int startByte = 0x40;
         string path;
         string trophyconf_version;
         public string npcommid;
@@ -36,7 +35,7 @@ namespace TROPHYParser
                 return trophys[index];
             }
         }
-        public TROPCONF(string path)
+        public TROPCONF(string path, bool isRpcs3Format)
         {
             if (path == null || path.Trim() == string.Empty)
                 throw new Exception("Path cannot be null!");
@@ -49,6 +48,7 @@ namespace TROPHYParser
             this.path = path;
 
             byte[] data = File.ReadAllBytes(fileName);
+            int startByte = isRpcs3Format ? 0x00 : 0x40;
             data = data.SubArray(startByte, data.Length - startByte);
 
             XmlDocument xmldoc = new XmlDocument();

--- a/TROPHYParser/TROPTRNS.cs
+++ b/TROPHYParser/TROPTRNS.cs
@@ -37,6 +37,7 @@ namespace TROPHYParser
     {
 
         private const string TROPTRNS_FILE_NAME = "TROPTRNS.DAT";
+        private bool isRpcs3Format;
 
         string path;
         Header header;
@@ -82,8 +83,13 @@ namespace TROPHYParser
 
         TrophyInitTime trophyInitTime;
 
-        public TROPTRNS(string path)
+        public TROPTRNS(string path, bool isRpcs3Format)
         {
+            if (isRpcs3Format)
+            {
+                this.isRpcs3Format = isRpcs3Format;
+                return;
+            }
             if (path == null || path.Trim() == string.Empty)
                 throw new Exception("Path cannot be null!");
 
@@ -169,6 +175,7 @@ namespace TROPHYParser
 
         public void Save()
         {
+            if (isRpcs3Format) return;
             using (var fileStream = new FileStream(Path.Combine(path, TROPTRNS_FILE_NAME), FileMode.Open))
             using (var TROPTRNSWriter = new BigEndianBinaryWriter(fileStream))
             {


### PR DESCRIPTION
Support read/write for the [RPCS3 ](https://rpcs3.net/)emulator trophy format:
- change startByte in `TROPCONF.cs`
- ignore completely `TROPTRNS` file
- fix `TROPUSR.cs` and:
    - create an empty `trophyListInfo` since rcps3 doesn't have that
    - save only type `4` and `6` data types since the rest are not present in rcps3

This is a dependency of: https://github.com/darkautism/PS3TrophyIsGood/pull/40

Tested with the following titles: NPWR00745_00 (Dante's Inferno), NPWR00801_00 (God of War II), NPWR00867_00 (Red Dead Redemption), NPWR01125_00 (NIER), NPWR02071_00 (God of War: Ghost of Sparta), NPWR03073_00 (The Last of Us), NPWR03581_00 (Sly Cooper: Thieves in Time)